### PR TITLE
mssql patch to enable persist & metadata method

### DIFF
--- a/provider/sdk/feast_azure_provider/mssqlserver.py
+++ b/provider/sdk/feast_azure_provider/mssqlserver.py
@@ -28,7 +28,11 @@ from feast import errors
 from feast.data_source import DataSource
 from .mssqlserver_source import MsSqlServerSource
 from feast.feature_view import FeatureView
-from feast.infra.offline_stores.offline_store import OfflineStore
+from feast.infra.offline_stores.offline_store import (
+    OfflineStore,
+    RetrievalJob,
+    RetrievalMetadata,
+)
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
 )
@@ -38,6 +42,8 @@ from feast.infra.provider import (
 )
 from feast.registry import Registry
 from feast.repo_config import FeastBaseModel, RepoConfig
+from feast.saved_dataset import SavedDatasetStorage
+from feast import FileSource
 
 EntitySchema = Dict[str, np.dtype]
 
@@ -278,6 +284,7 @@ class MsSqlServerRetrievalJob(RetrievalJob):
         config: RepoConfig,
         full_feature_names: bool,
         on_demand_feature_views: Optional[List[OnDemandFeatureView]],
+        metadata: Optional[RetrievalMetadata] = None,
         drop_columns: Optional[List[str]] = None,
     ):
         self.query = query
@@ -286,6 +293,7 @@ class MsSqlServerRetrievalJob(RetrievalJob):
         self._full_feature_names = full_feature_names
         self._on_demand_feature_views = on_demand_feature_views
         self._drop_columns = drop_columns
+        self._metadata = metadata
 
     @property
     def full_feature_names(self) -> bool:
@@ -301,6 +309,29 @@ class MsSqlServerRetrievalJob(RetrievalJob):
     def _to_arrow_internal(self) -> pyarrow.Table:
         result = pandas.read_sql(self.query, con=self.engine).fillna(value=np.nan)
         return pyarrow.Table.from_pandas(result)
+    
+    ## Implements persist in Feast 0.18 - This persists to filestorage
+    ## ToDo: Persist to Azure Storage 
+    def persist(self, storage: SavedDatasetStorage):
+        assert isinstance(storage, SavedDatasetFileStorage)
+
+        filesystem, path = FileSource.create_filesystem_and_path(
+            storage.file_options.file_url, storage.file_options.s3_endpoint_override,
+        )
+
+        if path.endswith(".parquet"):
+            pyarrow.parquet.write_table(
+                self.to_arrow(), where=path, filesystem=filesystem
+            )
+        else:
+            # otherwise assume destination is directory
+            pyarrow.parquet.write_to_dataset(
+                self.to_arrow(), root_path=path, filesystem=filesystem
+            )
+
+    @property
+    def metadata(self) -> Optional[RetrievalMetadata]:
+        return self._metadata
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
- Implement persist and metadata method introduced in feast 0.18
- Persist persists to filestorage, in future it will be good to persist to Azure storage 