### PR TITLE
Limit feast-azure-provider to 0.18.1

### DIFF
--- a/provider/sdk/setup.py
+++ b/provider/sdk/setup.py
@@ -29,7 +29,7 @@ setup(
     python_requires=">=3.7.0",
     packages=find_packages(exclude=("tests",)),
     install_requires=[
-        "feast[redis]~=0.18",
+        "feast[redis]==0.18.1",
         "azure-storage-blob>=0.37.0",
         "azure-identity>=1.6.1",
         "SQLAlchemy>=1.4.19",


### PR DESCRIPTION
-Temporary limit feast-azure-provider to 0.18.1
-Found a breaking bug on 0.19.x 

Error:
RegistryInferenceFailure: Inference to fill in missing information for DataSource failed. DataSource inferencing of event_timestamp_column is currently only supported for FileSource, SparkSource, BigQuerySource, RedshiftSource, and SnowflakeSource.